### PR TITLE
Markdown README and setup access right

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
-include *.conf *.txt *.rst
+include *.conf *.txt *.md
 recursive-include tests *.py
 recursive-include tests/data/specs *.spec
 recursive-include tests/data/Test* *.xml *.rpm *.xml.gz

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import os
 
 
 here = os.path.abspath(os.path.dirname(__file__))
-README = open(os.path.join(here, 'README.rst')).read()
+README = open(os.path.join(here, 'README.md')).read()
 
 
 class clean(Command):
@@ -55,13 +55,13 @@ class install(_install):
     def run(self):
         # Install the plugin code
         yumplugins_coderoot = os.path.join(self.root, "usr/lib/yum-plugins/")
-        self.mkpath(yumplugins_coderoot, mode=755)
+        self.mkpath(yumplugins_coderoot, mode=0755)
         self.copy_file("posttrans-triggers.py", yumplugins_coderoot,
                        preserve_mode=0)
 
         # Install the plugin conf
         yumplugins_confroot = os.path.join(self.root, "etc/yum/pluginconf.d/")
-        self.mkpath(yumplugins_confroot, mode=755)
+        self.mkpath(yumplugins_confroot, mode=0755)
         self.copy_file("posttrans-triggers.conf", yumplugins_confroot,
                        preserve_mode=0)
 


### PR DESCRIPTION
- Include READEME.md in MANIFEST.in.
- Revise setup.py to load README of markdown, not rst.
- Correct the access right of install directory created.